### PR TITLE
Add FreeBSD support

### DIFF
--- a/dehydrated/config.sls
+++ b/dehydrated/config.sls
@@ -14,7 +14,6 @@ dehydrated-config:
     - source: salt://dehydrated/files/config
     - mode: 644
     - user: root
-    - group: root
     - template: jinja
     - context:
         use_default_hook: {{ install_hook }}
@@ -26,7 +25,6 @@ dehydrated-hook:
     - source: {{ dehydrated.hook_script_src }}
     - mode: 755
     - user: root
-    - group: root
     - template: jinja
 {% endif %}
 
@@ -36,5 +34,4 @@ dehydrated-domains:
     - source: salt://dehydrated/files/domains.txt
     - mode: 644
     - user: root
-    - group: root
     - template: jinja

--- a/dehydrated/files/config
+++ b/dehydrated/files/config
@@ -6,15 +6,21 @@
    })
 -%}
 {%- if use_default_hook -%}
-{%- do cfg_client.setdefault('hook', dehydrated.hook_script) -%}
+  {%- do cfg_client.setdefault('hook', dehydrated.hook_script) -%}
 {%- endif -%}
+
+{#- Some defaults are platform-specific -#}
+{%- set wellknown_default =
+    '/var/www/letsencrypt' if grains.os_family != 'FreeBSD' else
+    '/usr/local/www/dehydrated' -%}
+
 {%- macro get_config(configname, default_value) -%}
-{%- set varname = configname.replace("-", "_") -%}
-{%- if configname in cfg_client -%}
+  {%- set varname = configname.replace("-", "_") -%}
+  {%- if configname in cfg_client -%}
 {{ varname|upper }}="{{ cfg_client[configname] }}"
-{%- else -%}
+  {%- else -%}
 #{{ varname|upper }}="{{ default_value }}"
-{%- endif -%}
+  {%- endif -%}
 {%- endmacro -%}
 # This file is managed by Salt, do not edit by hand!
 # Based on dehydrated version 0.3.0 default config
@@ -64,8 +70,8 @@
 {{ get_config('accountdir', '${BASEDIR}/accounts') }}
 
 # Output directory for challenge-tokens to be served by webserver or
-# deployed in HOOK (default: /var/www/letsencrypt)
-{{ get_config('wellknown', '/var/www/letsencrypt') }}
+# deployed in HOOK (default: {{ wellknown_default }})
+{{ get_config('wellknown', wellknown_default) }}
 
 # Default keysize for private keys (default: 4096)
 {{ get_config('keysize', '4096') }}

--- a/dehydrated/files/hook
+++ b/dehydrated/files/hook
@@ -5,7 +5,7 @@
 {% from "dehydrated/map.jinja" import dehydrated with context %}
 {% if dehydrated.hook_service_to_reload %}
 if [ "$1" = "deploy_cert" ]; then
-    export PATH="/sbin:/bin:/usr/sbin:/usr/bin"
+    export PATH="/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin:/usr/local/sbin"
     service {{ dehydrated.hook_service_to_reload }} reload
 fi
 {% else %}

--- a/dehydrated/map.jinja
+++ b/dehydrated/map.jinja
@@ -16,6 +16,12 @@ that differ from whats in defaults.yaml
         'Suse': {},
         'Arch': {},
         'RedHat': {},
+        'FreeBSD': {
+          'config_file': '/usr/local/etc/dehydrated/config',
+          'basedir': '/usr/local/etc/dehydrated',
+          'domains_txt': '/usr/local/etc/dehydrated/domains.txt',
+          'hook_script': '/usr/local/etc/dehydrated/hook',
+        },
   }
   , grain="os_family"
   , merge=salt['pillar.get']('dehydrated:lookup'))


### PR DESCRIPTION
Add FreeBSD support

* Stop explicitly using the `root` group.
  The files already inherit the correct group, so adding a special case for
  FreeBSD (where root's group is `wheel`) seems unnecessary.
* Ensure default paths match the ones used in the dehydrated port:
  https://github.com/freebsd/freebsd-ports/tree/master/security/dehydrated
